### PR TITLE
New feature: Emit a cyberpunk2020.weaponFired hook after an attack resolves

### DIFF
--- a/module/item/item.js
+++ b/module/item/item.js
@@ -548,6 +548,15 @@ export class CyberpunkItem extends Item {
           let roll = new Multiroll(`${localize("Autofire")}`, `${localize("Range")}: ${localizeParam(attackMods.range, {range: actualRangeBracket})}`);
           await roll.execute(undefined, "systems/cyberpunk2020/templates/chat/multi-hit.hbs", templateData);
           rolls.push(roll);
+
+          // Announce the resolved attack so add-on modules can react to it (e.g. damage automation).
+          Hooks.callAll("cyberpunk2020.weaponFired", {
+              attackerId: this.actor?.id ?? null,
+              weaponName: this.name,
+              areaDamages,
+              targetTokenId: targetTokens?.[i]?.id ?? null,
+              targetActorId: targetTokens?.[i]?.actor?.id ?? attackMods.targetActor?.id ?? null,
+          });
       }
 
       return rolls;
@@ -614,6 +623,14 @@ export class CyberpunkItem extends Item {
       };
       let roll = new Multiroll(localize("ThreeRoundBurst"));
       roll.execute(undefined, "systems/cyberpunk2020/templates/chat/multi-hit.hbs", templateData);
+
+      // Announce the resolved attack so add-on modules can react to it (e.g. damage automation).
+      Hooks.callAll("cyberpunk2020.weaponFired", {
+          attackerId: this.actor?.id ?? null,
+          weaponName: this.name,
+          areaDamages,
+          targetActorId: attackMods.targetActor?.id ?? null,
+      });
       if (rangedFumble?.outcome?.discharge) {
         await this.__setWeaponField("shotsLeft", 0);
       } else {
@@ -721,6 +738,14 @@ export class CyberpunkItem extends Item {
       let roll = new Multiroll(localize("SemiAuto"));
       roll.execute(undefined, "systems/cyberpunk2020/templates/chat/multi-hit.hbs", templateData);
 
+      // Announce the resolved attack so add-on modules can react to it (e.g. damage automation).
+      Hooks.callAll("cyberpunk2020.weaponFired", {
+          attackerId: this.actor?.id ?? null,
+          weaponName: this.name,
+          areaDamages,
+          targetActorId: attackMods.targetActor?.id ?? null,
+      });
+
       if (rangedFumble?.outcome?.discharge) {
         await this.__setWeaponField("shotsLeft", 0);
       } else {
@@ -791,6 +816,14 @@ export class CyberpunkItem extends Item {
           fumble
         }
       );
+
+      // Announce the resolved attack so add-on modules can react to it (e.g. damage automation).
+      Hooks.callAll("cyberpunk2020.weaponFired", {
+          attackerId: this.actor?.id ?? null,
+          weaponName: this.name,
+          areaDamages,
+          targetActorId: attackMods.targetActor?.id ?? null,
+      });
 
       return bigRoll;
   }


### PR DESCRIPTION
Each fire mode (`__fullAuto`, `__threeRoundBurst`, `__semiAuto`, `__meleeBonk`) emits a `Hooks.callAll("cyberpunk2020.weaponFired", ...)` right after it resolves the attack, passing the data it already computes for the chat card:

```js
Hooks.callAll("cyberpunk2020.weaponFired", {
  attackerId,            // this.actor.id
  weaponName,            // this.name
  areaDamages,           // the per-location damage map already built for multi-hit.hbs
  targetActorId,         // attackMods.targetActor.id (full auto also carries targetTokenId)
});
```

**Why:** it lets an add-on module react to a shot (for example, apply damage to the target automatically) by listening to a hook, instead of monkey-patching the roll methods - which is fragile and breaks whenever you touch that code.

**Safety / why it's risk-free:**
- Purely **additive** - nothing in the system reads this hook, so with no listener present the behaviour is byte-for-byte unchanged.
- Foundry isolates hook-listener errors, so a buggy listener can never affect the attack.
- It reuses `areaDamages` you already build - no new resolution logic, no new fields.

**Scope:** the four standard fire modes. Suppressive fire and the martial-arts path can get the same one-liner later if it's useful; I left them out to keep this minimal.

**Consumer:** this is the seam for the *Cyberpunk 2020: Augmented Edition* add-on module, which listens and applies the RAW damage/armor/wound resolution on top - keeping all of that automation out of the core system.