### PR TITLE
New feature: Emit a cyberpunkSkillRolled hook when a skill is rolled

### DIFF
--- a/module/actor/actor.js
+++ b/module/actor/actor.js
@@ -851,6 +851,16 @@ export class CyberpunkActor extends Actor {
     const skill = this.items.get(skillId);
     if (!skill) return;
 
+    // Announce the skill roll so add-on modules (e.g. an Improvement-Points tracker) can react to it.
+    // Additive + non-blocking: a listener error must never interrupt the roll.
+    try {
+      Hooks.callAll("cyberpunkSkillRolled", {
+        actorId: this.id, skillId: skill.id, actorName: this.name, skillName: skill.name
+      });
+    } catch (e) {
+      console.warn("cyberpunk2020 | cyberpunkSkillRolled hook listener failed", e);
+    }
+
     // generate the list of modifiers
     const parts = [
       CyberpunkActor.realSkillValue(skill),


### PR DESCRIPTION
`rollSkill` emits a hook at the top (covering every result path) with the actor and the skill:

```js
Hooks.callAll("cyberpunkSkillRolled", {
  actorId, skillId, actorName, skillName
});
```

**Why:** it lets an add-on module react to skill use - for example, an Improvement-Points tracker that queues a skill for a possible IP award - without patching the roll path.

**Safety:** additive and non-blocking. The emit is wrapped in try/catch so a listener error can never interrupt the roll, and nothing in the system depends on the hook.

**Naming:** I matched the existing per-roll event style. If you'd prefer it namespaced as `cyberpunk2020.skillRolled` to line up with `cyberpunk2020.weaponFired`, that's a one-word change - your call.

**Consumer:** the *Cyberpunk 2020: Augmented Edition* add-on (its IP tracker listens for this).