### PR TITLE
Fixed: actors with an invalid system.icon fail to load after the 1.1.1 patch

### DIFF
--- a/module/data/actor-data.js
+++ b/module/data/actor-data.js
@@ -7,6 +7,7 @@ import {
   filePathField,
   htmlField,
   mergeDefaults,
+  normalizeIconPath,
   numberField,
   objectField,
   stringField
@@ -101,9 +102,6 @@ class CyberpunkBaseActorData extends foundry.abstract.TypeDataModel {
         if (!hasOwn(source, key)) source[key] = value;
       }
     }
-    if (source.icon && typeof source.icon === "object") {
-      source.icon = source.icon.default ?? "";
-    }
 
     if (hasOwn(source, "stats")) source.stats = mergeDefaults(source.stats, DEFAULT_STATS);
     if (hasOwn(source, "hitLocations")) source.hitLocations = mergeDefaults(source.hitLocations, DEFAULT_HIT_LOCATIONS);
@@ -115,7 +113,7 @@ class CyberpunkBaseActorData extends foundry.abstract.TypeDataModel {
     if (hasOwn(source, "transient")) source.transient = mergeDefaults(source.transient, { skillFilter: "" });
     if (hasOwn(source, "_cwChecks")) source._cwChecks = mergeDefaults(source._cwChecks, { saveStun: 0 });
     if (hasOwn(source, "skillsSortedBy")) source.skillsSortedBy ||= "Name";
-    if (hasOwn(source, "icon")) source.icon ??= "";
+    if (hasOwn(source, "icon")) source.icon = normalizeIconPath(source.icon);
     if (hasOwn(source, "notes")) source.notes ??= "";
 
     return super.migrateData(source);

--- a/module/data/schema-helpers.js
+++ b/module/data/schema-helpers.js
@@ -48,6 +48,25 @@ export function filePathField(initial = "", categories = ["IMAGE"]) {
   return new FilePathField({ required: true, nullable: false, initial, categories, blank: true });
 }
 
+/**
+ * Coerce a stored icon value into something the IMAGE `filePathField` above will accept.
+ *
+ * Legacy worlds can hold an icon that is a template-wrapper object, or a plain string with no
+ * (or a non-image) file extension. Foundry v13+ validates FilePathField on load, so such a value
+ * throws "icon: does not have a valid file extension" and makes the WHOLE actor fail to load.
+ * We mirror the field's own check (CONST.FILE_CATEGORIES.IMAGE, so this can never drift from what
+ * the field accepts) and fall back to "" (blank is allowed) when the value is unusable; the icon
+ * can simply be re-selected afterwards.
+ */
+export function normalizeIconPath(value, fallback = "") {
+  if (value && typeof value === "object") value = value.default ?? fallback;
+  if (typeof value !== "string" || value === "") return fallback;
+  const image = CONST.FILE_CATEGORIES.IMAGE;
+  const { hasFileExtension, isBase64Data } = foundry.data.validators;
+  const isImage = hasFileExtension(value, Object.keys(image)) || isBase64Data(value, Object.values(image));
+  return isImage ? value : fallback;
+}
+
 export function mergeDefaults(source, defaults) {
   source ??= {};
   const mergeObject = globalThis.foundry?.utils?.mergeObject;

--- a/module/migrate.js
+++ b/module/migrate.js
@@ -1,4 +1,5 @@
 import { deleteFieldUpdate, getDefaultSkills, localize, cwHasType } from "./utils.js";
+import { normalizeIconPath } from "./data/schema-helpers.js";
 
 /**
  * Migration entrypoint.
@@ -185,9 +186,13 @@ function migrateLegacyActorSystemShape(actor, actorUpdates) {
     }
   }
 
-  // Very old template default could leave an object instead of a concrete path string.
-  if (sourceSystem.icon && typeof sourceSystem.icon === "object") {
-    actorUpdates["system.icon"] = sourceSystem.icon.default ?? "";
+  // A legacy icon — a template-wrapper object, or a string with no valid image extension —
+  // fails the IMAGE FilePathField validation and makes the actor unloadable. Coerce the pending
+  // icon (from the netrun copy above or an existing top-level value) into a value the field accepts.
+  const pendingIcon = "system.icon" in actorUpdates ? actorUpdates["system.icon"] : sourceSystem.icon;
+  if (pendingIcon) {
+    const normalizedIcon = normalizeIconPath(pendingIcon);
+    if (normalizedIcon !== pendingIcon) actorUpdates["system.icon"] = normalizedIcon;
   }
 
   if (sourceSystem.notes === null) actorUpdates["system.notes"] = "";


### PR DESCRIPTION
Fixes the "129 unavailable Actor documents" / `icon: does not have a valid file extension` breakage some worlds hit after the 1.1.1 patch.

## Cause
`system.icon` (the netrunner Runner Icon, previously `system.netrun.icon`) is an IMAGE `FilePathField`. Foundry v13+ validates it on load, so a legacy value that is either a template-wrapper object **or a plain string with no / an unrecognised file extension** throws `icon: does not have a valid file extension` -- which makes the WHOLE actor fail to construct, so it shows up as "unavailable".

`CyberpunkBaseActorData.migrateData` already flattened the object case (`icon.default`) but never sanitised a bad **string**, and the same gap exists in the world migration (`migrateLegacyActorSystemShape`). A world whose actors carry such a value therefore loses most of its actors -- and the world migration cannot repair them, because they fail to load before it runs.

## Fix
A small shared helper `normalizeIconPath()` that coerces any stored icon into something the field accepts. It mirrors the field's own check (`CONST.FILE_CATEGORIES.IMAGE` via `foundry.data.validators`), so it can never drift from what `FilePathField` allows, and falls back to `""` (blank is allowed) only when the value is genuinely unusable. Both the per-load `migrateData` and the world migration now route through it. Valid icons -- including base64 image data and an object carrying a valid `default` -- are preserved; a dropped icon can simply be re-selected. This also de-duplicates the icon handling that was copy-pasted across the two files.

## Verification
Reproduced and fixed against the actual `v1.1.1-dev` code on Foundry, constructing a `CyberpunkActor` from legacy sources the way the loader does (`new` -> `migrateData` -> validate):

| source `system` | before | after |
| --- | --- | --- |
| `netrun.icon: "systems/.../runner"` (no ext) | throws `... valid file extension` | loads, icon `""` |
| `netrun.icon: "Default Runner"` | throws | loads, icon `""` |
| `icon: "netrunner-deck"` | throws | loads, icon `""` |
| `netrun.icon: "icons/svg/mystery-man.svg"` | loads | loads (preserved) |
| `netrun.icon: { default: "icons/svg/item-bag.svg" }` | loads | loads (preserved) |
| `netrun.icon: ""` | loads | loads |

Touches 3 files: `module/data/schema-helpers.js` (new helper), `module/data/actor-data.js`, `module/migrate.js`.